### PR TITLE
3 create basic hunter entity

### DIFF
--- a/app/Http/Controllers/HunterController.php
+++ b/app/Http/Controllers/HunterController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreHunterRequest;
+use App\Http\Requests\UpdateHunterRequest;
+use App\Models\Hunter;
+
+class HunterController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        try {
+            return response()->json(HunterService::getAll())->setStatusCode(JsonResponse::HTTP_OK);
+        } catch (Exception $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreHunter $request):JsonResponse
+    {
+        try {
+            return response()->json(HunterService::create($request->validated()))->setStatusCode(JsonResponse::HTTP_CREATED);
+        } catch (Exception $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Hunter $hunter)
+    {
+        try {
+            return response()->json(HunterService::getById($hunter->id))->setStatusCode(JsonResponse::HTTP_OK);
+        } catch (ModelNotFoundException $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_NOT_FOUND);
+        } catch (Exception $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(HunterUpdate $request, Hunter $hunter): JsonResponse
+    {
+        try {
+            return response()->json(HunterService::update($request->validated(), $hunter->id))->setStatusCode(JsonResponse::HTTP_OK);
+        } catch (ModelNotFoundException $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_NOT_FOUND);
+        } catch (Exception $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Hunter $hunter): JsonResponse
+    {
+        try {
+            return response()->json(HunterService::delete($hunter->id))->setStatusCode(JsonResponse::HTTP_OK);
+        } catch (ModelNotFoundException $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_NOT_FOUND);
+        } catch (Exception $ex) {
+            return response()->json(self::formatMessage($ex->getMessage(), $ex->code ?? null))->setStatusCode(JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/app/Http/Requests/StoreHunterRequest.php
+++ b/app/Http/Requests/StoreHunterRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreHunterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateHunterRequest.php
+++ b/app/Http/Requests/UpdateHunterRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateHunterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -41,9 +41,9 @@ class Campaign extends Model
      *
      * @return HasMany
      */
-    // public function hunters(): HasMany
-    // {
-    //     return $this->hasMany(Hunter::class);
-    // }
+    public function hunters(): HasMany
+    {
+        return $this->hasMany(Hunter::class);
+    }
 
 }

--- a/app/Models/Hunter.php
+++ b/app/Models/Hunter.php
@@ -4,9 +4,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Iluminate\Database\Eloquent\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Hunter extends Model
 {
+
+    /** @use HasFactory<\Database\Factories\HunterFactory> */
+    use HasFactory, SoftDeletes;
+
       /** @var string $table table used to store the model */
     protected $table = 'hunters';
 

--- a/app/Models/Hunter.php
+++ b/app/Models/Hunter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Iluminate\Database\Eloquent\BelongsTo;
+
+class Hunter extends Model
+{
+      /** @var string $table table used to store the model */
+    protected $table = 'hunters';
+
+     /** @var string $primaryKey The primary key associated with the table */
+    protected $primaryKey = 'id';
+
+    /** @var array $fillable Attributes that are mass assignable */
+    protected $fillable = [
+        'playerName',
+        'hunterName',
+        'campaignId'
+    ];
+
+     /**
+     * Campaing related to this hunter
+     *
+     * @return BelongsTo
+     **/
+    public function campaign(): BelongsTo
+    {
+        return self::belongsTo(Campaing::class, 'campaignId', 'id');
+    }
+}

--- a/database/factories/HunterFactory.php
+++ b/database/factories/HunterFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Hunter>
+ */
+class HunterFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'hunter'=> fake()->word(),
+            'campaignId'=>Campaign::factory(),
+        ];
+    }
+}

--- a/database/factories/HunterFactory.php
+++ b/database/factories/HunterFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Campaign;
+use App\Models\Hunter;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Hunter>
@@ -17,8 +19,8 @@ class HunterFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'hunter'=> fake()->word(),
+            'playerName' => fake()->name(),
+            'hunterName'=> fake()->word(),
             'campaignId'=>Campaign::factory(),
         ];
     }

--- a/database/migrations/2025_06_26_040720_create_hunters_table.php
+++ b/database/migrations/2025_06_26_040720_create_hunters_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('hunters', function (Blueprint $table) {
+            $table->id();
+            $table->string('playerName')->nullable(false);
+            $table->string('hunterName')->nullable(false);
+            $table->foreignId('campaignId')->references('id')->on('campaigns');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('hunters');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
         self::call([
             MapSeeder::class,
             CampaignSeeder::class,
+            HunterSeeder::class,
         ]);
     }
 }

--- a/database/seeders/HunterSeeder.php
+++ b/database/seeders/HunterSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Campaign;
+use App\Models\Hunter;
 
 class HunterSeeder extends Seeder
 {

--- a/database/seeders/HunterSeeder.php
+++ b/database/seeders/HunterSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class HunterSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    
+    public function run(): void
+    {
+        Campaign::all()->each(function ($campaign){
+            Hunter::factory(rand(1,4))->create([
+                'campaignId'=>$campaign->id,
+            ]);
+        });
+    }
+}


### PR DESCRIPTION
This PR´s goal is to fix #3.

Hunters Model, controller and migration are now enabled.

Hunters model has a relationship with Campaigns table using its id, up to 4 hunters can be created for each Campaign using its seeder.

Hunter CRUD endpoints are now available.

